### PR TITLE
Add CI via Github Actions

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,0 +1,22 @@
+name: WUEST API
+on: [push, pull_request]
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v1
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        working-directory: ./api
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          sudo apt-get update && sudo apt-get install make
+      - name: Test with pytest
+        working-directory: ./api
+        run: |
+          make test

--- a/api/Makefile
+++ b/api/Makefile
@@ -2,6 +2,12 @@ SH := /bin/sh
 PY := $(shell which python3)
 MULTIPROC_DIR ?= $(shell pwd)/.multiproc_dir
 
+.PHONY: help
+## help: prints this help message
+help:
+	@echo "Usage: \n"
+	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'
+
 .PHONY: test
 ## test: run unit tests
 test:
@@ -29,9 +35,3 @@ run/prod:
 ## clean: cleans .multiproc_dir
 clean:
 	find $(MULTIPROC_DIR) -type f -not -regex ".*gitkeep$$" -exec rm "{}" \;
-
-.PHONY: help
-## help: prints this help message
-help:
-	@echo "Usage: \n"
-	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'


### PR DESCRIPTION
This introduces a continuous integration workflow via [Github Actions](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/about-github-actions). 

Once this is merged, on every push and pull request an action should run that will call the `make test` target. You can see this in action on [my wuestbot fork](https://github.com/obitech/wuestbot/actions).

Closes #14 